### PR TITLE
PATCH: changes to sum aggregation to allow compatibility with NSE

### DIFF
--- a/src/scores/continuous/nse_impl.py
+++ b/src/scores/continuous/nse_impl.py
@@ -25,6 +25,7 @@ import numpy as np
 import xarray as xr
 
 import scores.continuous
+from scores.continuous.standard_impl import population_weighted_squared_error
 from scores.processing import broadcast_and_match_nan
 from scores.typing import (
     FlexibleDimensionTypes,
@@ -362,7 +363,7 @@ class NseMetaInput(NamedTuple):
         """
         # safety: dev/testing only
         assert isinstance(x1, xr.Dataset) and isinstance(x2, xr.Dataset)
-        ret: xr.Dataset = scores.continuous.mse(
+        ret: xr.Dataset = population_weighted_squared_error(
             x1,
             x2,
             reduce_dims=self.gathered_dims,

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -2,6 +2,7 @@
 This module contains standard methods which may be used for continuous scoring
 """
 
+import functools
 from typing import Optional, Union
 
 import numpy as np
@@ -10,12 +11,67 @@ import xarray as xr
 import scores.functions
 import scores.utils
 from scores.processing import aggregate, broadcast_and_match_nan
+from scores.processing.aggregation import raise_if_invalid_aggregation_method
 from scores.typing import (
     FlexibleArrayType,
     FlexibleDimensionTypes,
     XarrayLike,
     is_xarraylike,
 )
+
+
+def aggregate_squared_error(
+    fcst: FlexibleArrayType,
+    obs: FlexibleArrayType,
+    *,  # Force keywords arguments to be keyword-only
+    reduce_dims: Optional[FlexibleDimensionTypes] = None,
+    preserve_dims: Optional[FlexibleDimensionTypes] = None,
+    weights: Optional[xr.DataArray] = None,
+    is_angular: Optional[bool] = False,
+    aggregate_method: Optional[str] = "mean",
+):
+    """
+    Internal function used for aggregating squared errors.
+
+    For example weighted-mse is essentially a aggregate of squared errors with
+    a weighted mean.
+    """
+    raise_if_invalid_aggregation_method(aggregate_method)
+
+    if is_xarraylike(fcst) and is_xarraylike(obs):
+        reduce_dims = scores.utils.gather_dimensions(
+            fcst.dims,
+            obs.dims,
+            reduce_dims=reduce_dims,
+            preserve_dims=preserve_dims,
+        )
+
+    if is_angular:
+        error = scores.functions.angular_difference(fcst, obs)  # type: ignore
+    else:
+        error = fcst - obs  # type: ignore
+
+    squared = error * error
+
+    if is_xarraylike(squared):
+        result = aggregate(
+            squared,
+            reduce_dims=reduce_dims,
+            weights=weights,
+            method=aggregate_method,
+        )
+    else:
+        # support for non-xarray data with assumed sum/mean methods.
+        match aggregate_method:
+            case "sum":
+                result = squared.sum()
+            case "mean":
+                result = squared.mean()
+            case _:
+                # already checked at the top of the function
+                raise RuntimeError("unreachable")
+
+    return result
 
 
 def mse(
@@ -70,21 +126,106 @@ def mse(
             Otherwise: Returns an object representing the mean squared error,
             reduced along the relevant dimensions and weighted appropriately.
     """
-    if is_xarraylike(fcst):
-        reduce_dims = scores.utils.gather_dimensions(
-            fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims
+    return aggregate_squared_error(
+        fcst,
+        obs,
+        reduce_dims=reduce_dims,
+        preserve_dims=preserve_dims,
+        weights=weights,
+        is_angular=is_angular,
+        aggregate_method="mean",
+    )
+
+
+def population_weighted_squared_error(
+    fcst: FlexibleArrayType,
+    obs: FlexibleArrayType,
+    *,  # Force keywords arguments to be keyword-only
+    reduce_dims: Optional[FlexibleDimensionTypes] = None,
+    preserve_dims: Optional[FlexibleDimensionTypes] = None,
+    weights: Optional[xr.DataArray] = None,
+    is_angular: bool = False,
+):
+    """
+    Like mse but scaled over the population count rather than the weighted norm.
+
+    Takes the same args & kwargs as mse.
+
+    NOTE:
+        - this function is currently only internally used
+        - it is somewhat equivilent to the old style of weighting (apart from
+          NaN handling)
+        - it can be faster for scores that are computed as weighted fractionals
+          over the same population, since it avoids having to compute the
+          weighted norm. (e.g. NSE)
+        - division by population count is a "safety" measure to avoid having to
+          process large numbers.
+    """
+    LARGE_POPULATION_THRESHOLD = 1e5
+
+    # weights is None - this is the same as mse
+    if weights is None:
+        return mse(
+            fcst,
+            obs,
+            reduce_dims=reduce_dims,
+            preserve_dims=preserve_dims,
+            weights=weights,
+            is_angular=is_angular,
         )
 
-    if is_angular:
-        error = scores.functions.angular_difference(fcst, obs)  # type: ignore
-    else:
-        error = fcst - obs  # type: ignore
-    squared = error * error
+    def _population_count_of_reduced_dims():
+        if is_xarraylike(fcst) and is_xarraylike(obs):
+            _reduce_dims = scores.utils.gather_dimensions(
+                fcst.dims,
+                obs.dims,
+                reduce_dims=reduce_dims,
+                preserve_dims=preserve_dims,
+            )
 
-    if is_xarraylike(squared):
-        result = aggregate(squared, reduce_dims=reduce_dims, weights=weights)
+            # attempt to get dimension length from forecast, else observation,
+            # else default to 1 (identity for product-type)
+            dim_lengths = [
+                fcst.sizes.get(
+                    _dim,
+                    obs.sizes.get(_dim, 1),
+                )
+                for _dim in _reduce_dims
+            ]
+
+            return np.prod(dim_lengths)
+
+        else:
+            # no reduction will be applied for non-xarraylike
+            return 1
+
+    population_count = _population_count_of_reduced_dims()
+    remaining_divisor = 1
+    is_large_population = population_count > LARGE_POPULATION_THRESHOLD
+
+    if is_large_population:
+        # if population is large, split divisor into two parts, pre-division
+        # and post-division
+        weights = weights / LARGE_POPULATION_THRESHOLD
+        remaining_divisor = population_count / LARGE_POPULATION_THRESHOLD
     else:
-        result = squared.mean()
+        # otherwise directly divide by population count
+        weights = weights / population_count
+
+    # compute sum with population scaled weights
+    result = aggregate_squared_error(
+        fcst,
+        obs,
+        reduce_dims=reduce_dims,
+        preserve_dims=preserve_dims,
+        weights=weights,
+        is_angular=is_angular,
+        aggregate_method="sum",
+    )
+
+    # population count is large - post divide result instead
+    if is_large_population:
+        result = result / remaining_divisor
 
     return result
 

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -67,8 +67,8 @@ def aggregate_squared_error(
                 result = squared.sum()
             case "mean":
                 result = squared.mean()
-            case _:
-                # already checked at the top of the function
+            case _:  # pragma: no cover
+                # safety: already checked at the top of the function
                 raise RuntimeError("unreachable")
 
     return result
@@ -174,30 +174,30 @@ def population_weighted_squared_error(
             is_angular=is_angular,
         )
 
+    if not is_xarraylike(fcst) or not is_xarraylike(obs):
+        raise NotImplementedError(
+            "`population_weighted_squared_error` only supports weighting with xarray-like inputs."
+        )
+
     def _population_count_of_reduced_dims():
-        if is_xarraylike(fcst) and is_xarraylike(obs):
-            _reduce_dims = scores.utils.gather_dimensions(
-                fcst.dims,
-                obs.dims,
-                reduce_dims=reduce_dims,
-                preserve_dims=preserve_dims,
+        _reduce_dims = scores.utils.gather_dimensions(
+            fcst.dims,
+            obs.dims,
+            reduce_dims=reduce_dims,
+            preserve_dims=preserve_dims,
+        )
+
+        # attempt to get dimension length from forecast, else observation,
+        # else default to 1 (identity for product-type)
+        dim_lengths = [
+            fcst.sizes.get(
+                _dim,
+                obs.sizes.get(_dim, 1),
             )
+            for _dim in _reduce_dims
+        ]
 
-            # attempt to get dimension length from forecast, else observation,
-            # else default to 1 (identity for product-type)
-            dim_lengths = [
-                fcst.sizes.get(
-                    _dim,
-                    obs.sizes.get(_dim, 1),
-                )
-                for _dim in _reduce_dims
-            ]
-
-            return np.prod(dim_lengths)
-
-        else:
-            # no reduction will be applied for non-xarraylike
-            return 1
+        return np.prod(dim_lengths)
 
     population_count = _population_count_of_reduced_dims()
     remaining_divisor = 1

--- a/src/scores/fast/fss/fss_numba.py
+++ b/src/scores/fast/fss/fss_numba.py
@@ -1,6 +1,6 @@
 """
 Backend for computing Fractions Skill Score (FSS) using numba
-    
+
 """
 
 from dataclasses import dataclass

--- a/src/scores/fast/fss/typing.py
+++ b/src/scores/fast/fss/typing.py
@@ -1,5 +1,5 @@
 """
-Specific type definitions for Fss backend    
+Specific type definitions for Fss backend
 """
 
 from enum import Enum

--- a/src/scores/processing/aggregation.py
+++ b/src/scores/processing/aggregation.py
@@ -147,7 +147,7 @@ def aggregate(
                 return _weighted_sum(values, weights, reduce_dims)
             return values.sum(reduce_dims)
         case _:  # pragma: no cover
-            # already checked in _check_aggregate_inputs
+            # safety: checked in _check_aggregate_inputs()
             raise ERROR_UNREACHABLE
 
 
@@ -169,7 +169,7 @@ def _weighted_mean(
 
     xarray doesn't allow ``.weighted`` to take ``xr.Dataset`` as weights, so we need to do it ourselves
     """
-    # safety: checked in aggregate()
+    # safety: checked in _check_aggregate_inputs() and aggregate()
     assert reduce_dims is not None
     assert weights is not None
 
@@ -191,7 +191,7 @@ def _weighted_mean(
 
         return xr.Dataset(w_results)
 
-    # safety: weights should not be a dataset due to checks in _check_aggregate_inputs.
+    # safety: checked in _check_aggregate_inputs()
     # note: values can still be a dataset.
     assert not is_dataset(weights)
 
@@ -241,27 +241,27 @@ def _weighted_sum(
     # - weights = dataarray (or similar) and values = dataset
     if is_dataset(values):
         w_results = {}
-        w = weights  # assume weights are arrays/dataarrays
+        w = weights  # default: assume weights are arrays/dataarrays
 
+        # ---
+        # if `weights` is a dataset,
+        #   extract the `weights` array that matches the variable name in
+        #   `values` and use that to do the weighted sum;
+        # otherwise,
+        #   for all variables in `values`, perform weighted sum with the
+        #   constant `weights` array.
+        # ---
         for name, da in values.data_vars.items():
-            # if weights are actually datasets, attempt to extract the
-            # appropriate variable
             if is_dataset(weights):
-                # ---
-                # safety: this is already checked in _check_aggregate_inputs;
-                # if 'weights' is a dataset, it cannot be broadcast to an
-                # unspecified variable in 'values' and vice-versa, because a
-                # concept of a "default" does not exist.
-                if name not in weights:  # pragma: no cover
-                    raise ERROR_UNREACHABLE
-                # ---
+                # safety: checked in _check_aggregate_inputs()
+                assert name in weights
                 w = weights[name]
 
             w_results[name] = _reduce_sum(da, w, reduce_dims)
 
         return xr.Dataset(w_results)
 
-    # safety: only remaining options due to checks in _check_aggregate_inputs
+    # safety: checked in _check_aggregate_inputs()
     assert not is_dataset(values)
     assert not is_dataset(weights)
 
@@ -293,7 +293,7 @@ def _check_aggregate_inputs(
         weights: The weights to apply for weighted averaging in :py:func:`aggregate`.
         method: The aggregation method to use, either "mean" or "sum" in :py:func:`aggregate`.
     """
-    # safety: should have returned before reaching this point.
+    # safety: checked in aggregate()
     if reduce_dims is None:  # pragma: no cover
         raise ERROR_UNREACHABLE
 

--- a/src/scores/processing/aggregation.py
+++ b/src/scores/processing/aggregation.py
@@ -5,11 +5,15 @@ Functions related to aggregating data
 import warnings
 from typing import Optional
 
+import numpy as np
 import xarray as xr
 
 from scores.processing.matching import broadcast_and_match_nan
 from scores.typing import FlexibleDimensionTypes, XarrayLike
 from scores.utils import check_weights
+
+
+SUPPORTED_METHODS_STR = ["mean", "sum"]
 
 
 def aggregate(
@@ -84,10 +88,18 @@ def aggregate(
             if weights is not None:
                 return _weighted_mean(values, weights, reduce_dims)
             return values.mean(reduce_dims)
-        case "sum":  # pragma: no cover - invalid method is checked in `_check_aggregate_inputs`
+        case "sum":
             if weights is not None:
                 return _weighted_sum(values, weights, reduce_dims)
             return values.sum(reduce_dims)
+        case _:
+            # already checked in check_weights
+            raise RuntimeError("unreachable")
+
+
+def raise_if_invalid_aggregation_method(method: str):
+    if (not isinstance(method, str)) or (method not in SUPPORTED_METHODS_STR):
+        raise ValueError(f"Method must be one of {SUPPORTED_METHODS_STR}, got '{method}'")
 
 
 def _weighted_mean(
@@ -100,6 +112,10 @@ def _weighted_mean(
 
     xarray doesn't allow ``.weighted`` to take ``xr.Dataset`` as weights, so we need to do it ourselves
     """
+    # safety
+    assert reduce_dims is not None
+    assert weights is not None
+
     if isinstance(weights, xr.Dataset):
         w_results = {}
         for name, da in values.data_vars.items():
@@ -110,7 +126,9 @@ def _weighted_mean(
             # has at least one positive value and will raise an error.
             # However, if a value in w_aligned.sum(dim=reduce_dims) is zero,
             # a NaN will be produced for that point.
-            w_results[name] = (da_aligned * w_aligned).sum(dim=reduce_dims) / w_aligned.sum(dim=reduce_dims)
+            w_numerator = (da_aligned * w_aligned).sum(dim=reduce_dims)
+            w_denominator = w_aligned.sum(dim=reduce_dims)
+            w_results[name] = w_numerator / w_denominator
 
         return xr.Dataset(w_results)
 
@@ -126,12 +144,56 @@ def _weighted_sum(
 ) -> XarrayLike:
     """
     Calculated the weighted sum of `values` using `weights` over specified dimensions.
+
+    TODO: install opt_einsum for optimized summations.
     """
-    values = values.weighted(weights)
-    summed_values = values.sum(reduce_dims)
-    # Handle NaNs in `values`
-    summed_values = summed_values.where(~xr.ufuncs.isnan(values.mean(reduce_dims)))
-    return summed_values
+    def _align_and_fillzero(_v, _w, _dims):
+        fn_nan = xr.ufuncs.isnan
+        v_aligned, w_aligned = broadcast_and_match_nan(_v, _w)
+
+        # zero out masked values since they don't need to be summed
+        result = (v_aligned.fillna(0), w_aligned.fillna(0))
+
+        # get reduced mask to mask out nans
+        # - only need to do this for v_aligned, since w_aligned is matched.
+        nan_mask = xr.ufuncs.isnan(v_aligned).all(dim=_dims)
+
+        return result, nan_mask
+
+    def _reduce_sum(_v, _w, _dims):
+        _vw, nan_mask = _align_and_fillzero(_v, _w, _dims)
+        _v, _w = _vw
+        result = None
+
+        if _dims is None:
+            # None has a different behaviour in xr.dot
+            result = xr.dot(_v, _w)
+        else:
+            result = xr.dot(_v, _w, dim=_dims)
+
+        # safety
+        assert result is not None
+
+        return result.where(~nan_mask, np.nan)
+
+    if isinstance(values, xr.Dataset):
+        w_results = {}
+        # assume weights are data arrays
+        w = weights
+
+        for name, da in values.data_vars.items():
+            # if they are datasets, extract the underlying array instead
+            if isinstance(weights, xr.Dataset):
+                w = weights[name]
+            w_results[name] = _reduce_sum(da, w, reduce_dims)
+
+        return xr.Dataset(w_results)
+
+    # safety: These should already be checked
+    assert isinstance(values, xr.DataArray)
+    assert not isinstance(weights, xr.Dataset)
+
+    return _reduce_sum(values, weights, reduce_dims)
 
 
 def _check_aggregate_inputs(
@@ -155,8 +217,7 @@ def _check_aggregate_inputs(
         method: The aggregation method to use, either "mean" or "sum" in :py:func:`aggregate`.
 
     """
-    if method not in ["mean", "sum"]:
-        raise ValueError(f"Method must be either 'mean' or 'sum', got '{method}'")
+    raise_if_invalid_aggregation_method(method)
 
     if weights is not None:
         check_weights(weights)
@@ -173,10 +234,6 @@ def _check_aggregate_inputs(
         if weights is not None:
             # xarray doesn't allow .weighted to take xr.Dataset as weights, so we need to do it ourselves
             if isinstance(weights, xr.Dataset):
-                if method == "sum":
-                    raise NotImplementedError(
-                        "using the method 'sum' with weights that are xr.Datasets is not currently supported"
-                    )
                 if isinstance(values, xr.DataArray):
                     raise ValueError("`weights` cannot be an xr.Dataset when `values` is an xr.DataArray")
                 for name in values.data_vars:

--- a/src/scores/processing/aggregation.py
+++ b/src/scores/processing/aggregation.py
@@ -12,7 +12,6 @@ from scores.processing.matching import broadcast_and_match_nan
 from scores.typing import FlexibleDimensionTypes, XarrayLike
 from scores.utils import check_weights
 
-
 SUPPORTED_METHODS_STR = ["mean", "sum"]
 
 
@@ -256,7 +255,10 @@ def _weighted_sum(
 
 
 def _check_aggregate_inputs(
-    values: XarrayLike, reduce_dims: FlexibleDimensionTypes | None, weights: XarrayLike | None, method: str,
+    values: XarrayLike,
+    reduce_dims: FlexibleDimensionTypes | None,
+    weights: XarrayLike | None,
+    method: str,
 ):
     """
     This function checks the inputs to the aggregate function.

--- a/src/scores/processing/aggregation.py
+++ b/src/scores/processing/aggregation.py
@@ -22,40 +22,40 @@ def _aggregate_error_builder(name, error_type=Exception):
     return type(name, (error_type,), {})
 
 
-AggregateError_InputKey = _aggregate_error_builder("InputKeyError", KeyError)
+AggregateErrorInputKey = _aggregate_error_builder("InputKeyError", KeyError)
 
-AggregateError_InputValue = _aggregate_error_builder("InputValueError", ValueError)
+AggregateErrorInputValue = _aggregate_error_builder("InputValueError", ValueError)
 
-AggregateError_InputType = _aggregate_error_builder("InputTypeError", TypeError)
+AggregateErrorInputType = _aggregate_error_builder("InputTypeError", TypeError)
 
-AggregateError_Compute = _aggregate_error_builder("ComputeError", ValueError)
+AggregateErrorCompute = _aggregate_error_builder("ComputeError", ValueError)
 
-AggregateError_Critical = _aggregate_error_builder("CriticalError", RuntimeError)
+AggregateErrorCritical = _aggregate_error_builder("CriticalError", RuntimeError)
 
 
 # black is not setup to format long strings properly
 # fmt: off
 
 # usage: raise ERROR_UNREACHABLE
-ERROR_UNREACHABLE = AggregateError_Critical(
+ERROR_UNREACHABLE = AggregateErrorCritical(
     "CRITICAL FAILURE! Unreachable code, please raise a github ticket quoting "
     "any traceback logs."
 )
 
 # usage: raise ERROR_INVALID_METHOD("agg")
-ERROR_INVALID_METHOD = lambda method: AggregateError_InputValue(
+ERROR_INVALID_METHOD = lambda method: AggregateErrorInputValue(
     "Method must be one of {}, got '{}'".format(SUPPORTED_METHODS_STR, method)
-)
+) # pylint: disable=unnecessary-lambda-assignment, disable=consider-using-f-string
 
 # usage: raise ERROR_WEIGHT_TYPE_MISMATCH
-ERROR_WEIGHT_TYPE_MISMATCH = AggregateError_InputType(
+ERROR_WEIGHT_TYPE_MISMATCH = AggregateErrorInputType(
     "`weights` cannot be an xr.Dataset when `values` is an xr.DataArray"
 )
 
 # usage: raise ERROR_UNSPECIFIED_WEIGHTS_FOR_VARIABLE("var")
-ERROR_UNSPECIFIED_WEIGHTS_FOR_VARIABLE = lambda var_name: AggregateError_InputKey(
+ERROR_UNSPECIFIED_WEIGHTS_FOR_VARIABLE = lambda var_name: AggregateErrorInputKey(
     "No weights provided for variable '{}'".format(var_name)
-)
+) # pylint: disable=unnecessary-lambda-assignment, disable=consider-using-f-string
 
 # usage: warnings.warn(WARN_WEIGHTS_IGNORED_STR)
 WARN_WEIGHTS_IGNORED_STR = (
@@ -152,6 +152,9 @@ def aggregate(
 
 
 def raise_if_invalid_aggregation_method(method: str):
+    """
+    Raises ValueError if method is not in SUPPORTED_METHODS_STR
+    """
     if (not isinstance(method, str)) or (method not in SUPPORTED_METHODS_STR):
         raise ERROR_INVALID_METHOD(method)
 
@@ -166,11 +169,13 @@ def _weighted_mean(
 
     xarray doesn't allow ``.weighted`` to take ``xr.Dataset`` as weights, so we need to do it ourselves
     """
-    # safety
+    # safety: checked in aggregate()
     assert reduce_dims is not None
     assert weights is not None
 
-    if isinstance(weights, xr.Dataset):
+    is_dataset = lambda maybe_ds: isinstance(maybe_ds, xr.Dataset)  # pylint: disable=C3001
+
+    if is_dataset(values) and is_dataset(weights):
         w_results = {}
         for name, da in values.data_vars.items():
             w = weights[name]
@@ -185,6 +190,10 @@ def _weighted_mean(
             w_results[name] = w_numerator / w_denominator
 
         return xr.Dataset(w_results)
+
+    # safety: weights should not be a dataset due to checks in _check_aggregate_inputs.
+    # note: values can still be a dataset.
+    assert not is_dataset(weights)
 
     values = values.weighted(weights)
 
@@ -206,9 +215,11 @@ def _weighted_sum(
     """
     # safety: checked in aggregate()
     assert reduce_dims is not None
+    assert weights is not None
+
+    is_dataset = lambda maybe_ds: isinstance(maybe_ds, xr.Dataset)  # pylint: disable=C3001
 
     def _align_and_fillzero(_v, _w, _dims):
-        fn_nan = xr.ufuncs.isnan
         v_aligned, w_aligned = broadcast_and_match_nan(_v, _w)
 
         # zero out masked values since they don't need to be summed
@@ -225,14 +236,17 @@ def _weighted_sum(
         result = xr.dot(_v, _w, dim=_dims)
         return result.where(~nan_mask, np.nan)
 
-    if isinstance(values, xr.Dataset):
+    # handles:
+    # - weights = dataset and values = dataset
+    # - weights = dataarray (or similar) and values = dataset
+    if is_dataset(values):
         w_results = {}
         w = weights  # assume weights are arrays/dataarrays
 
         for name, da in values.data_vars.items():
             # if weights are actually datasets, attempt to extract the
             # appropriate variable
-            if isinstance(weights, xr.Dataset):
+            if is_dataset(weights):
                 # ---
                 # safety: this is already checked in _check_aggregate_inputs;
                 # if 'weights' is a dataset, it cannot be broadcast to an
@@ -247,12 +261,12 @@ def _weighted_sum(
 
         return xr.Dataset(w_results)
 
-    # ---
-    # safety: this is the only viable option
-    not_dataset = lambda maybe_ds: not isinstance(maybe_ds, xr.Dataset)
-    assert not_dataset(values) and not_dataset(weights)
-    # ---
+    # safety: only remaining options due to checks in _check_aggregate_inputs
+    assert not is_dataset(values)
+    assert not is_dataset(weights)
 
+    # handles:
+    # - weights = dataarray (or similar) and values = dataarray (or similar)
     return _reduce_sum(values, weights, reduce_dims)
 
 
@@ -288,7 +302,7 @@ def _check_aggregate_inputs(
     if weights is not None:
         check_weights(weights)
 
-        is_dataset = lambda maybe_ds: isinstance(maybe_ds, xr.Dataset)
+        is_dataset = lambda maybe_ds: isinstance(maybe_ds, xr.Dataset)  # pylint: disable=C3001
 
         # ---
         # weights cannot have more structural information than values

--- a/src/scores/processing/aggregation.py
+++ b/src/scores/processing/aggregation.py
@@ -16,6 +16,57 @@ from scores.utils import check_weights
 SUPPORTED_METHODS_STR = ["mean", "sum"]
 
 
+def _aggregate_error_builder(name, error_type=Exception):
+    """
+    Generic builder for various input error types
+    """
+    return type(name, (error_type,), {})
+
+
+AggregateError_InputKey = _aggregate_error_builder("InputKeyError", KeyError)
+
+AggregateError_InputValue = _aggregate_error_builder("InputValueError", ValueError)
+
+AggregateError_InputType = _aggregate_error_builder("InputTypeError", TypeError)
+
+AggregateError_Compute = _aggregate_error_builder("ComputeError", ValueError)
+
+AggregateError_Critical = _aggregate_error_builder("CriticalError", RuntimeError)
+
+
+# black is not setup to format long strings properly
+# fmt: off
+
+# usage: raise ERROR_UNREACHABLE
+ERROR_UNREACHABLE = AggregateError_Compute(
+    "CRITICAL FAILURE! Unreachable code, please raise a github ticket quoting "
+    "any traceback logs."
+)
+
+# usage: raise ERROR_INVALID_METHOD("agg")
+ERROR_INVALID_METHOD = lambda method: AggregateError_InputValue(
+    "Method must be one of {}, got '{}'".format(SUPPORTED_METHODS_STR, method)
+)
+
+# usage: raise ERROR_WEIGHT_TYPE_MISMATCH
+ERROR_WEIGHT_TYPE_MISMATCH = AggregateError_InputType(
+    "`weights` cannot be an xr.Dataset when `values` is an xr.DataArray"
+)
+
+# usage: raise ERROR_UNSPECIFIED_WEIGHTS_FOR_VARIABLE("var")
+ERROR_UNSPECIFIED_WEIGHTS_FOR_VARIABLE = lambda var_name: AggregateError_InputKey(
+    "No weights provided for variable '{}'".format(var_name)
+)
+
+# usage: warnings.warn(WARN_WEIGHTS_IGNORED_STR)
+WARN_WEIGHTS_IGNORED_STR = (
+    "Weights were provided but the point-wise score across all dimensions is "
+    "being preserved.\nWeights will be ignored."
+)
+
+# fmt: on
+
+
 def aggregate(
     values: XarrayLike,
     *,
@@ -78,10 +129,14 @@ def aggregate(
         Dimensions without coordinates: y
 
     """
-    _check_aggregate_inputs(values, reduce_dims, weights, method)
-
+    # bypass any computation if no dimensions are being reduced. (identity function)
     if reduce_dims is None:
+        # warn user if weights are provided without any reduction specified.
+        if weights is not None:
+            warnings.warn(WARN_WEIGHTS_IGNORED_STR)
         return values
+
+    _check_aggregate_inputs(values, reduce_dims, weights, method)
 
     match method:
         case "mean":
@@ -93,13 +148,13 @@ def aggregate(
                 return _weighted_sum(values, weights, reduce_dims)
             return values.sum(reduce_dims)
         case _:
-            # already checked in check_weights
-            raise RuntimeError("unreachable")
+            # already checked in _check_aggregate_inputs
+            raise ERROR_UNREACHABLE
 
 
 def raise_if_invalid_aggregation_method(method: str):
     if (not isinstance(method, str)) or (method not in SUPPORTED_METHODS_STR):
-        raise ValueError(f"Method must be one of {SUPPORTED_METHODS_STR}, got '{method}'")
+        raise ERROR_INVALID_METHOD(method)
 
 
 def _weighted_mean(
@@ -145,8 +200,14 @@ def _weighted_sum(
     """
     Calculated the weighted sum of `values` using `weights` over specified dimensions.
 
-    TODO: install opt_einsum for optimized summations.
+    FUTUREWORK:
+        - xr.dot uses einsum, which has an "optimized" mode, which apparently
+          speeds things up a lot - research this.
+        - add opt_einsum as a dependency for optimized summations.
     """
+    # safety: checked in aggregate()
+    assert reduce_dims is not None
+
     def _align_and_fillzero(_v, _w, _dims):
         fn_nan = xr.ufuncs.isnan
         v_aligned, w_aligned = broadcast_and_match_nan(_v, _w)
@@ -154,42 +215,40 @@ def _weighted_sum(
         # zero out masked values since they don't need to be summed
         result = (v_aligned.fillna(0), w_aligned.fillna(0))
 
-        # get reduced mask to mask out nans
-        # - only need to do this for v_aligned, since w_aligned is matched.
+        # get reduced mask to preserve nans, post computation
+        # NOTE: only need to do this for v_aligned, since w_aligned is matched.
         nan_mask = xr.ufuncs.isnan(v_aligned).all(dim=_dims)
 
         return result, nan_mask
 
     def _reduce_sum(_v, _w, _dims):
-        _vw, nan_mask = _align_and_fillzero(_v, _w, _dims)
-        _v, _w = _vw
-        result = None
-
-        if _dims is None:
-            # None has a different behaviour in xr.dot
-            result = xr.dot(_v, _w)
-        else:
-            result = xr.dot(_v, _w, dim=_dims)
-
-        # safety
-        assert result is not None
-
+        (_v, _w), nan_mask = _align_and_fillzero(_v, _w, _dims)
+        result = xr.dot(_v, _w, dim=_dims)
         return result.where(~nan_mask, np.nan)
 
     if isinstance(values, xr.Dataset):
         w_results = {}
-        # assume weights are data arrays
-        w = weights
+        w = weights  # assume weights are arrays/dataarrays
 
         for name, da in values.data_vars.items():
-            # if they are datasets, extract the underlying array instead
+            # if weights are actually datasets, attempt to extract the
+            # appropriate variable
             if isinstance(weights, xr.Dataset):
+                # ---
+                # safety: this is already checked in _check_aggregate_inputs;
+                # if 'weights' is a dataset, it cannot be broadcast to an
+                # unspecified variable in 'values' and vice-versa, because a
+                # concept of a "default" does not exist.
+                if name not in weights:
+                    raise ERROR_UNREACHABLE
+                # ---
                 w = weights[name]
+
             w_results[name] = _reduce_sum(da, w, reduce_dims)
 
         return xr.Dataset(w_results)
 
-    # safety: These should already be checked
+    # safety: these are the only viable options
     assert isinstance(values, xr.DataArray)
     assert not isinstance(weights, xr.Dataset)
 
@@ -197,7 +256,7 @@ def _weighted_sum(
 
 
 def _check_aggregate_inputs(
-    values: XarrayLike, reduce_dims: FlexibleDimensionTypes | None, weights: XarrayLike | None, method: str
+    values: XarrayLike, reduce_dims: FlexibleDimensionTypes | None, weights: XarrayLike | None, method: str,
 ):
     """
     This function checks the inputs to the aggregate function.
@@ -215,27 +274,32 @@ def _check_aggregate_inputs(
         reduce_dims: The dimensions over which to apply the mean in :py:func:`aggregate`.
         weights: The weights to apply for weighted averaging in :py:func:`aggregate`.
         method: The aggregation method to use, either "mean" or "sum" in :py:func:`aggregate`.
-
     """
+    is_dataset = lambda maybe_ds: isinstance(maybe_ds, xr.Dataset)
+
     raise_if_invalid_aggregation_method(method)
 
     if weights is not None:
         check_weights(weights)
 
-    if reduce_dims is None and weights is not None:
-        warnings.warn(
-            """
-            Weights were provided but the point-wise score across all dimensions is being preserved. 
-            Weights will be ignored.
-            """,
-            UserWarning,
-        )
-    if reduce_dims is not None:
-        if weights is not None:
-            # xarray doesn't allow .weighted to take xr.Dataset as weights, so we need to do it ourselves
-            if isinstance(weights, xr.Dataset):
-                if isinstance(values, xr.DataArray):
-                    raise ValueError("`weights` cannot be an xr.Dataset when `values` is an xr.DataArray")
+        if reduce_dims is not None:
+            # ---
+            # weights cannot have more structural information than values
+            # i.e.
+            # weights = dataarray, values = dataset - OK
+            # weights = dataset, values = dataarray or numpy array - NOT OK
+            # if they are the same type - OK
+            if is_dataset(weights) and not is_dataset(values):
+                raise ERROR_WEIGHT_TYPE_MISMATCH
+            # ---
+
+            # ---
+            # if both `values` and `weights` are datasets,
+            # check that all variables in `values` are present in `weights`,
+            # otherwise `weights` is underspecified, and therefore the weighted
+            # aggregation is ambiguous.
+            if is_dataset(weights) and is_dataset(values):
                 for name in values.data_vars:
                     if name not in weights:
-                        raise KeyError(f"No weights provided for variable '{name}'")
+                        raise ERROR_UNSPECIFIED_WEIGHTS_FOR_VARIABLE(name)
+            # ---

--- a/src/scores/processing/aggregation.py
+++ b/src/scores/processing/aggregation.py
@@ -146,7 +146,7 @@ def aggregate(
             if weights is not None:
                 return _weighted_sum(values, weights, reduce_dims)
             return values.sum(reduce_dims)
-        case _:
+        case _:  # pragma: no cover
             # already checked in _check_aggregate_inputs
             raise ERROR_UNREACHABLE
 
@@ -238,7 +238,7 @@ def _weighted_sum(
                 # if 'weights' is a dataset, it cannot be broadcast to an
                 # unspecified variable in 'values' and vice-versa, because a
                 # concept of a "default" does not exist.
-                if name not in weights:
+                if name not in weights:  # pragma: no cover
                     raise ERROR_UNREACHABLE
                 # ---
                 w = weights[name]
@@ -247,9 +247,11 @@ def _weighted_sum(
 
         return xr.Dataset(w_results)
 
-    # safety: these are the only viable options
-    assert isinstance(values, xr.DataArray)
-    assert not isinstance(weights, xr.Dataset)
+    # ---
+    # safety: this is the only viable option
+    not_dataset = lambda maybe_ds: not isinstance(maybe_ds, xr.Dataset)
+    assert not_dataset(values) and not_dataset(weights)
+    # ---
 
     return _reduce_sum(values, weights, reduce_dims)
 
@@ -277,31 +279,34 @@ def _check_aggregate_inputs(
         weights: The weights to apply for weighted averaging in :py:func:`aggregate`.
         method: The aggregation method to use, either "mean" or "sum" in :py:func:`aggregate`.
     """
-    is_dataset = lambda maybe_ds: isinstance(maybe_ds, xr.Dataset)
+    # safety: should have returned before reaching this point.
+    if reduce_dims is None:  # pragma: no cover
+        raise ERROR_UNREACHABLE
 
     raise_if_invalid_aggregation_method(method)
 
     if weights is not None:
         check_weights(weights)
 
-        if reduce_dims is not None:
-            # ---
-            # weights cannot have more structural information than values
-            # i.e.
-            # weights = dataarray, values = dataset - OK
-            # weights = dataset, values = dataarray or numpy array - NOT OK
-            # if they are the same type - OK
-            if is_dataset(weights) and not is_dataset(values):
-                raise ERROR_WEIGHT_TYPE_MISMATCH
-            # ---
+        is_dataset = lambda maybe_ds: isinstance(maybe_ds, xr.Dataset)
 
-            # ---
-            # if both `values` and `weights` are datasets,
-            # check that all variables in `values` are present in `weights`,
-            # otherwise `weights` is underspecified, and therefore the weighted
-            # aggregation is ambiguous.
-            if is_dataset(weights) and is_dataset(values):
-                for name in values.data_vars:
-                    if name not in weights:
-                        raise ERROR_UNSPECIFIED_WEIGHTS_FOR_VARIABLE(name)
-            # ---
+        # ---
+        # weights cannot have more structural information than values
+        # i.e.
+        # weights = dataarray, values = dataset - OK
+        # weights = dataset, values = dataarray or numpy array - NOT OK
+        # if they are the same type - OK
+        if is_dataset(weights) and not is_dataset(values):
+            raise ERROR_WEIGHT_TYPE_MISMATCH
+        # ---
+
+        # ---
+        # if both `values` and `weights` are datasets,
+        # check that all variables in `values` are present in `weights`,
+        # otherwise `weights` is underspecified, and therefore the weighted
+        # aggregation is ambiguous.
+        if is_dataset(weights) and is_dataset(values):
+            for name in values.data_vars:
+                if name not in weights:
+                    raise ERROR_UNSPECIFIED_WEIGHTS_FOR_VARIABLE(name)
+        # ---

--- a/src/scores/processing/aggregation.py
+++ b/src/scores/processing/aggregation.py
@@ -37,7 +37,7 @@ AggregateError_Critical = _aggregate_error_builder("CriticalError", RuntimeError
 # fmt: off
 
 # usage: raise ERROR_UNREACHABLE
-ERROR_UNREACHABLE = AggregateError_Compute(
+ERROR_UNREACHABLE = AggregateError_Critical(
     "CRITICAL FAILURE! Unreachable code, please raise a github ticket quoting "
     "any traceback logs."
 )

--- a/src/scores/stats/statistical_tests/acovf.py
+++ b/src/scores/stats/statistical_tests/acovf.py
@@ -1,7 +1,7 @@
 """
 Estimate autocovariances
 
-Barebones reimplementation of the `acovf` from `statsmodels.api.tsa.acovf`, 
+Barebones reimplementation of the `acovf` from `statsmodels.api.tsa.acovf`,
 for use only with `scores.stats.test.diebold_mariano`
 
 Package: https://www.statsmodels.org/devel/
@@ -9,7 +9,7 @@ Package: https://www.statsmodels.org/devel/
 Code reference: https://github.com/statsmodels/statsmodels/blob/main/statsmodels/tsa/stattools.py
 
 Notes:
-    All type checking and other features have been removed, as they aren't needed for the 
+    All type checking and other features have been removed, as they aren't needed for the
     `diebold_mariano` function.
 
 Why:

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -19,6 +19,10 @@ import pytest
 import xarray as xr
 
 import scores.continuous
+from scores.continuous.standard_impl import (
+    aggregate_squared_error,
+    population_weighted_squared_error,
+)
 
 PRECISION = 4
 
@@ -1136,3 +1140,100 @@ def test_kge_errors(fcst, obs, scaling_factors, expected_exception, expected_mes
     """
     with pytest.raises(expected_exception, match=expected_message):
         scores.continuous.kge(fcst, obs, scaling_factors=scaling_factors)  # type: ignore
+
+
+def test_population_weighted_squared_error():
+    """
+    Test population_weighted_squared_error:
+        - population >1e5: should split division in stages
+        - population <=1e5: should divide in one go
+    """
+    # ----------------------------
+    # Scenario 1: Large population
+    # ----------------------------
+    # slightly above threshold, so that we don't make things too large
+    size_large_population = int(1e5 + 5e4)
+    expected_pre_division = 1e5  # unused - for reference only
+    expected_post_divsion = 1.5  # unused - for reference only
+
+    # keep preserved dimensions small so verification is easy to construct
+    size_preserved_dimensions = (3, 2)
+
+    size_tuple = (size_large_population, *size_preserved_dimensions)
+    dim_names = ("x", "y", "z")
+    reduce_dims = ["x"]
+
+    # use float32 to reduce computational load
+    fcst = xr.DataArray(data=np.zeros(size_tuple), dims=dim_names)
+    obs = xr.DataArray(data=np.ones(size_tuple), dims=dim_names)
+    weights = xr.DataArray(data=2 * np.ones(size_tuple), dims=dim_names)
+    expected = xr.DataArray(data=2 * np.ones(size_preserved_dimensions), dims=("y", "z"))
+    result = population_weighted_squared_error(fcst, obs, weights=weights, reduce_dims=reduce_dims)
+
+    xr.testing.assert_allclose(result, expected)
+
+    # -----------------------------------------
+    # Scenario 2: Small (<threshold) population
+    # -----------------------------------------
+    size_tuple = (10, 3, 2)
+    dim_names = ("x", "y", "z")
+    reduce_dims = ["x"]
+    fcst = xr.DataArray(data=np.zeros(size_tuple), dims=dim_names)
+    obs = xr.DataArray(data=np.ones(size_tuple), dims=dim_names)
+    weights = xr.DataArray(data=2 * np.ones(size_tuple), dims=dim_names)
+    expected = xr.DataArray(
+        data=2
+        * np.ones(
+            size_preserved_dimensions,
+        ),
+        dims=("y", "z"),
+    )
+    result = population_weighted_squared_error(fcst, obs, weights=weights, reduce_dims=reduce_dims)
+
+    xr.testing.assert_allclose(result, expected)
+
+    # --------------------------------------------------
+    # Scenario 3: Non-xarray: raises NotImplementedError
+    # --------------------------------------------------
+    expected_pre_division = 1e5  # unused - for reference only
+    expected_post_divsion = 9  # unused - for reference only
+    size_tuple = (size_large_population, *size_preserved_dimensions)
+    fcst = np.zeros(size_tuple)
+    obs = np.ones(size_tuple)
+    weights = 2 * np.ones(size_tuple)
+
+    with pytest.raises(NotImplementedError):
+        result = population_weighted_squared_error(fcst, obs, weights=weights)
+
+
+def test_aggregate_squared_error_numpy():
+    """
+    NOTE: most of this is tested by `mse` or `population_weighted_squared_error`
+
+    This test focuses on numpy-like objects without labelled dimensions.
+
+    Since scores currently doesn't support reduction of non-labelled
+    dimensions, they will be completely reduced, regardless of weights
+    """
+    fcst = 2 * np.ones((2, 2))
+    obs = np.zeros((2, 2))
+
+    # ---------------------------------
+    # Scenario 1: Sum of squared errors
+    # ---------------------------------
+    result = aggregate_squared_error(fcst, obs, aggregate_method="sum")
+    expected = 16
+    assert result - expected < 1e-6
+
+    # ----------------------------------
+    # Scenario 2: Mean of squared errors
+    # ----------------------------------
+    result = aggregate_squared_error(fcst, obs, aggregate_method="mean")
+    expected = 4
+    assert result - expected < 1e-6
+
+    # ------------------------------
+    # Scenario 3: Unsupported method
+    # ------------------------------
+    with pytest.raises(ValueError):
+        result = aggregate_squared_error(fcst, obs, aggregate_method="agg")

--- a/tests/processing/cdf/functions_test_data.py
+++ b/tests/processing/cdf/functions_test_data.py
@@ -1,5 +1,5 @@
 """
-Data for probability tests. 
+Data for probability tests.
 """
 
 import numpy as np

--- a/tests/processing/test_aggregation.py
+++ b/tests/processing/test_aggregation.py
@@ -196,6 +196,13 @@ def test_aggregate_sum(values, reduce_dims, weights, expected):
     expected_ds = xr.Dataset(({"var1": expected, "var2": expected}))
     xr.testing.assert_equal(result_ds, expected_ds)
 
+    # Check with xr.Dataset for both values and weights
+    if weights is not None:
+        weights_ds = xr.Dataset(({"var1": weights, "var2": weights}))
+        result_ds = aggregate(values_ds, reduce_dims=reduce_dims, weights=weights_ds, method="sum")
+        expected_ds = xr.Dataset(({"var1": expected, "var2": expected}))
+        xr.testing.assert_equal(result_ds, expected_ds)
+
 
 def test_agg_warns():
     """

--- a/tests/processing/test_aggregation.py
+++ b/tests/processing/test_aggregation.py
@@ -51,7 +51,7 @@ EXP_DA_VARY = xr.DataArray(
     coords={"x": [0, 1, 2]},
 )
 EXP_DA_VARY_SUM = xr.DataArray(
-    [4, 7, np.nan],
+    [4, 7, 0],
     dims=["x"],
     coords={"x": [0, 1, 2]},
 )
@@ -246,7 +246,7 @@ def test_agg_warns():
             ValueError,
         ),
         # Wrong method
-        (DA_3x3, None, "agg", "Method must be either 'mean' or 'sum', got 'agg'", ValueError),
+        (DA_3x3, None, "agg", "Method must be one of \['mean', 'sum'\], got 'agg'", ValueError),
         # DS weights missing data var
         (
             xr.Dataset(({"var1": DA_3x3, "var2": DA_3x3})),
@@ -255,21 +255,13 @@ def test_agg_warns():
             "No weights provided for variable 'var2'",
             KeyError,
         ),
-        # DS weights and method=sum
-        (
-            xr.Dataset(({"var1": DA_3x3, "var2": DA_3x3})),
-            xr.Dataset(({"var1": WEIGHTS1, "var2": WEIGHTS1})),
-            "sum",
-            "using the method 'sum' with weights that are xr.Datasets is not currently supported",
-            NotImplementedError,
-        ),
         # DA values, DS weights
         (
             DA_3x3,
             xr.Dataset(({"var1": WEIGHTS1, "var2": WEIGHTS1})),
             "mean",
             "`weights` cannot be an xr.Dataset when `values` is an xr.DataArray",
-            ValueError,
+            TypeError,
         ),
     ],
 )


### PR DESCRIPTION
- Added sum aggregation compatibility with datasets
- Fixed up score-specific tests
- Some extra `standard_impl` methods that allow compatibility for population weighted sums - this is essentially "variance" but applied on the population over `reduce_dims` (N rather than N-1 degrees of freedom). This is used by NSE, and incidentally coincided with the old implementation of mse (barring NaNs), rather than a weighted mean.

TODO:
* [x] Some aggregation tests are currently failing due to the added `sum` compatibility to datasets.