### PR TITLE
fix NSE tests to adhere to new weighted mse calculations

### DIFF
--- a/tests/continuous/test_nse.py
+++ b/tests/continuous/test_nse.py
@@ -873,13 +873,22 @@ class TestNseScore(NseSetup):
         # - NOTE:
         #    we will have two different values for weights, repeated at specific positions because
         #    of the way it is reduced.
-
         # temperature
+        # --- IMPORTANT ---
+        # [NR: 2025-09-02]
+        # These values have been modified due to recent changes in weight logic.
+        # They have to be scaled in terms of weight sum rather than count
+        # reference PR: 887-improve-weighting.
+        # ---
         te1 = 4.0 / 3.0
+        te1 = te1 / (4 / 3.0)  # [887-improve-weighting] invert scale from population to weights
         tv1 = 10.0 / 3.0
+        tv1 = tv1 / (4 / 3.0)  # [887-improve-weighting] invert scale from population to weights
         ts1 = 3.0 / 5.0
         te2 = 3.0
+        te2 = te2 / (9 / 3.0)  # [887-improve-weighting] invert scale from population to weights
         tv2 = 186.0 / 24.0
+        tv2 = tv2 / (9 / 3.0)  # [887-improve-weighting] invert scale from population to weights
         ts2 = 114.0 / 186.0
 
         # result depends on x axis, and must be 2*4
@@ -899,6 +908,7 @@ class TestNseScore(NseSetup):
         # precipitation - note precipitation only has one value for weights
         pe1 = 0.0
         pv1 = 61.0 / 24.0
+        pv1 = pv1 / (5 / 6.0)  # [887-improve-weighting] invert scale from population to weights
         ps1 = 1.0
         exp_precip_fcst_err_weights = _build_exp_output_da(pe1, "precipitation")
         exp_precip_obs_var_weights = _build_exp_output_da(pv1, "precipitation")

--- a/tests/processing/cdf/functions_test_data.py
+++ b/tests/processing/cdf/functions_test_data.py
@@ -1,5 +1,5 @@
 """
-Data for probability tests. 
+Data for probability tests.
 """
 
 import numpy as np


### PR DESCRIPTION
Notes for reviewer:

The tests failed because of the discrepency in the aggregation strategy using the current weighting scheme compared to the precious. Since wNSE (this score) relies on the computation of population variance, and the previous MwSE (mean of weighted squared error terms) did the exact same thing, it was a intuitive choice to re-use the logic.

However given that the weights are now normalized the individual components themselves are not exactly the same. Despite this - the final score is not affected since any scaling is cancelled out.

We _may_ have to revisit things down the track, but for now I think it is ok.